### PR TITLE
Fixes and Improvements

### DIFF
--- a/core/src/main/java/com/grydtech/msstack/core/MicroserviceApplication.java
+++ b/core/src/main/java/com/grydtech/msstack/core/MicroserviceApplication.java
@@ -52,20 +52,26 @@ public abstract class MicroserviceApplication {
         final EventBroker eventBroker = EventBroker.getInstance();
         final RequestBroker requestBroker = RequestBroker.getInstance();
 
-        // Register Event Handlers
-        this.getEventHandlers().forEach(eventBroker::subscribe);
+        try {
+            // Register Event Handlers
+            this.getEventHandlers().forEach(eventBroker::subscribe);
 
-        // Register Request Handlers
-        this.getRequestHandlers().forEach(requestBroker::subscribe);
+            // Register Request Handlers
+            this.getRequestHandlers().forEach(requestBroker::subscribe);
 
-        // Start Event Broker
-        EventBroker.getInstance().start();
+            // Start Event Broker
+            EventBroker.getInstance().start();
 
-        // Start Request Broker
-        RequestBroker.getInstance().start();
+            // Start Request Broker
+            RequestBroker.getInstance().start();
 
-        // Register Service
+            // Register Service
 
-        // Optional
+            // Optional
+
+        } finally {
+            // Cleanup before termination
+            eventBroker.flush();
+        }
     }
 }

--- a/core/src/main/java/com/grydtech/msstack/core/component/EventBroker.java
+++ b/core/src/main/java/com/grydtech/msstack/core/component/EventBroker.java
@@ -27,6 +27,11 @@ public abstract class EventBroker implements AbstractBroker<EventHandler> {
      */
     public abstract void publish(Event event);
 
+    /**
+     * Flushes any buffered events and block until completion
+     */
+    public abstract void flush();
+
     @Override
     public final int getPort() {
         return getClass().getAnnotation(ServerComponent.class).port();

--- a/core/src/main/java/com/grydtech/msstack/util/DependencyInjectorUtils.java
+++ b/core/src/main/java/com/grydtech/msstack/util/DependencyInjectorUtils.java
@@ -36,7 +36,7 @@ public final class DependencyInjectorUtils {
             field.set(null, implementedClassInstance);
         }
         field.setAccessible(isFieldAccessible);
-        LOGGER.info(String.format("Injected - %s", field.getType().toGenericString()));
+        LOGGER.info(String.format("Injected - %s", field.getType().getName()));
     }
 
     /**


### PR DESCRIPTION
## Description
1. Add flush() method to EventBroker, which flushes remaining messages
before MicroserviceApplication shuts down.
2. Add a TaskQueue to KafkaBroker so that execution doesn't block if
Kafka server is down, and a timer to execute any pending tasks & flush.
3. Add error message to response body in Netty Server in case of an
exception.

## Known Issues
1. The MicroserviceApplication must block on something without
terminating

### Type of Change
- [x] Bugfix (a non-breaking change that fixes an issue)
- [x] Feature (a non-breaking change that adds functionality)
- [ ] Breaking Change (a feature/fix that could break existing functionality)

### Dependencies Added
e.g:
```
<dependency>
    <groupId>junit</groupId>
    <artifactId>junit</artifactId>
    <version>4.12</version>
</dependency>
```

## Testing Procedure
How has this feature/fix been tested?

### Test coverage
Mention the coverage of methods in code. e.g:
- [ ] MethodA
- [X] MethodB

### Test Configuration
* OS: (e.g: Ubuntu 18.04)
* SDK: (e.g: OpenJDK 8)

## Checklist
- [x] My code follows the style guidelines for this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation to reflect my changes.
- [x] My changes do not generate new warnings.
- [x] I have added tests to confirm that my fix is effective / my feature works.
- [x] New and existing unit tests pass with my changes.
- [x] Dependent changes have been merged and published in downstream modules.
